### PR TITLE
remove of double call by reference in menu_link_save(&). This is depr…

### DIFF
--- a/wisski_find.module
+++ b/wisski_find.module
@@ -1332,7 +1332,7 @@ function wisski_find_add_groups() {
     $item['hidden'] = isset($oldlinks[$group]['hidden']) ? $oldlinks[$group]['hidden'] : 0;
     $item['plid'] = isset($oldlinks[$group]['plid']) ? $oldlinks[$group]['plid'] : NULL;
     
-    $id = menu_link_save(&$item);
+    $id = menu_link_save($item);
     $saveIDs[$id] = $group;
     if($item['hidden'] == 0) { 
 


### PR DESCRIPTION
…ecated since ?, not allowed since php 5.3 and causes errors
